### PR TITLE
chore: update peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "example:build": "npm -C example run build"
   },
   "peerDependencies": {
-    "esbuild": "^0.11.0"
+    "esbuild": "^0.14.0"
   },
   "devDependencies": {
     "@hannoeru/eslint-config": "^0.6.0",


### PR DESCRIPTION
Caret (`^`) behavior is different for 0.x versions, for which it only matches patch versions. Because of this, package managers report an issue about unmet peer dependency, if version of the `esbuild` is `>=12.0`.

This can be fixed in few ways:
* update minor version to match the latest minor version of `esbuild` (like I did in this PR),
* use `"esbuild": ">=0.11 <=x.x"`, where it will match all versions between `0.11` and `x.x` (eg. `"esbuild": ">=0.11 <=0.14"`).

Using only `>=0.11` is dangerous for two reasons. First is that `esbuild` can still introduce breaking changes before they release `1.0`, so it's better to only allow versions that were tested. Second is that it will literally match everything after `0.11`, even `1.0`, `2.0`, etc.

Thank you for this awesome package 🙏