### PR TITLE
fix: do not output original file path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,18 @@ export default function rawPlugin(): Plugin {
     setup(build) {
       build.onResolve({ filter: /\?raw$/ }, (args) => {
         return {
-          path: path.isAbsolute(args.path) ? args.path : path.join(args.resolveDir, args.path),
+          path: args.path,
+          pluginData: {
+            isAbsolute: path.isAbsolute(args.path),
+            resolveDir: args.resolveDir,
+          },
           namespace: 'raw-loader',
         }
       })
       build.onLoad({ filter: /\?raw$/, namespace: 'raw-loader' }, async(args) => {
+        const fullPath = args.pluginData.isAbsolute ? args.path : path.join(args.pluginData.resolveDir, args.path);
         return {
-          contents: await readFile(args.path.replace(/\?raw$/, '')),
+          contents: await readFile(fullPath.replace(/\?raw$/, '')),
           loader: 'text',
         }
       })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is an attempt to fix #64.  
As I suspected just removing the `path.join` does not work when the source directory is no the working directory. I managed to keep the resolution working but hide the file path in the outputs by using `pluginData` object to pass context to he `onLoad` function.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
