### PR TITLE
fix: correctly handle imports with the same file name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,27 @@
 import type { Plugin } from 'esbuild'
 import { readFile } from 'node:fs/promises'
-import path from 'node:path'
+import { join } from 'node:path'
 
 export default function rawPlugin(): Plugin {
   return {
     name: 'raw',
     setup(build) {
       build.onResolve({ filter: /\?raw$/ }, (args) => {
+        const resolvedPath = join(args.resolveDir, args.path)
         return {
-          path: args.path,
-          pluginData: {
-            isAbsolute: path.isAbsolute(args.path),
-            resolveDir: args.resolveDir,
-          },
+          path: resolvedPath,
           namespace: 'raw-loader',
         }
       })
-      build.onLoad({ filter: /\?raw$/, namespace: 'raw-loader' }, async (args) => {
-        const fullPath = args.pluginData.isAbsolute ? args.path : path.join(args.pluginData.resolveDir, args.path)
-        return {
-          contents: await readFile(fullPath.replace(/\?raw$/, '')),
-          loader: 'text',
+      build.onLoad(
+        { filter: /\?raw$/, namespace: 'raw-loader' },
+        async (args) => {
+          return {
+            contents: await readFile(args.path.replace(/\?raw$/, '')),
+            loader: 'text',
+          }
         }
-      })
+      )
     },
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export default function rawPlugin(): Plugin {
             contents: await readFile(args.path.replace(/\?raw$/, '')),
             loader: 'text',
           }
-        }
+        },
       )
     },
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Let's say you have the following structure:
```
<root>
├── src
│   ├── bar
│   │   ├── index.ts
│   │   └── raw.ts
│   └── foo
│       ├── index.ts
│       └── raw.ts
├── tsup.config.ts
```

And both `src/foo/index.ts` and `src/bar/index.ts` import their relative `raw.ts` file with  `./raw.ts?raw`.
With the current implementation of the plugin, the content of `src/foo/raw.ts` will be the same as `src/bar/raw.ts`.

I'm not an expert with ESBuild, but I think it comes from the fact that ESBuild uses the returned `path` in `onResolve` as a deduplication key for the `onLoad` event. It means the `onLoad` will only be called once.
Because the current implementation doesn't resolve the full path in `onResolve`, the deduplication key is the same for both `<root>/src/foo/raw.ts` and `<root>/src/bar/raw.ts` → `./raw.ts`.

This PR fixes that by resolving the full path directly in `onResolve` so `onLoad` is called correctly.
I'm using the proposed version in my codebase and it works fine.

### Additional context

It might resolve #401, not sure about it.

Again, I'm not an expert with ESBuild, so I might be missing something here.
Let me know.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

